### PR TITLE
fix-errors: nestjs 7 pass back errors as an array of strings instead …

### DIFF
--- a/src/components/ErrorMessage.js
+++ b/src/components/ErrorMessage.js
@@ -20,9 +20,9 @@ const ErrorList = styled.ul`
 `;
 
 export default class ErrorMessage extends Component {
-  renderMessageArray = errors => {
-    const constraints = errors.map(error =>
-      Object.values(error.constraints))
+  renderMessageArray = (errors) => {
+    const constraints = errors
+      .map((error) => (error.constraints ? Object.values(error.constraints) : error))
       .flat()
       .map((constraint, idx) => <li key={idx}>{constraint}</li>);
 


### PR DESCRIPTION
…of an object. see more:  https://docs.nestjs.com/migration-guide\#validation-errors-schema. allow backwards compability with nestjs 6 or allows pass-thru errors for nestjs 7