### PR TITLE
Better error handling on login and signup; link to login from signup

### DIFF
--- a/src/pages/signin/SignInPage.js
+++ b/src/pages/signin/SignInPage.js
@@ -41,7 +41,7 @@ class SignInPage extends Component {
       await this.props.userStore.signin(username, password);
       this.props.routerStore.push('/tasks');
     } catch (error) {
-      const errorMessage = error.response.data.message;
+      const errorMessage = error.response ? error.response.data.message : error.message;
       this.setState({ errorMessage });
     }
   };

--- a/src/pages/signup/SignUpPage.js
+++ b/src/pages/signup/SignUpPage.js
@@ -40,9 +40,13 @@ class SignUpPage extends Component {
       await this.props.userStore.signup(username, password);
       this.props.routerStore.push('/signin');
     } catch (error) {
-      const errorMessage = error.response.data.message;
+      const errorMessage = error.response ? error.response.data.message : error.message;
       this.setState({ errorMessage });
     }
+  };
+
+  goToSignIn = () => {
+    this.props.routerStore.push('/signin')
   };
 
   render() {
@@ -76,7 +80,7 @@ class SignUpPage extends Component {
             />
           </div>
           <p>
-            Passwords must contain at least 1 upper case letter, 1 lower case letter and one number OR special charracter.
+            Passwords must contain at least 1 upper case letter, 1 lower case letter and one number OR special character.
           </p>
           <hr/>
           <div>
@@ -87,6 +91,10 @@ class SignUpPage extends Component {
               onClick={this.submit}
             >
               SIGN UP
+            </Button>
+
+            <Button fullWidth onClick={this.goToSignIn}>
+              Already have an account? Sign in here!
             </Button>
           </div>
         </FormContainer>


### PR DESCRIPTION
Just a couple of things I cleaned up while working through your NestJS course (which is great, btw - thank you!). When CORS isn't enabled in the Nest app, the error object doesn't even have a response property. The message just says "Network Error."

I also thought it would be helpful to add a link from the signup page to the signin page.